### PR TITLE
Enforce numpy-style docstrings via ruff pydocstyle

### DIFF
--- a/PyPWR/power_classes.py
+++ b/PyPWR/power_classes.py
@@ -74,6 +74,19 @@ class pwr_1n(abc.ABC):
         pass
 
     def pwr_test(self) -> dict[str, float | int | str | None]:
+        """Solve for the single unspecified parameter and return the full result.
+
+        Whichever of ``power``, ``effect_size``, ``n``, or ``sig_level`` was left
+        as ``None`` is computed (via root-finding for all but ``power``), and the
+        completed set of parameters is returned.
+
+        Returns
+        -------
+        dict[str, float | int | str | None]
+            The resolved parameters (``effect_size``, ``n``, ``sig_level``,
+            ``power``), along with ``alternative``, ``method``, and ``note`` when
+            a note is present.
+        """
         if self.power is None:
             self.power = self._get_power()
         elif self.effect_size is None:
@@ -176,6 +189,19 @@ class pwr_2n(abc.ABC):
         pass
 
     def pwr_test(self) -> dict[str, float | int | str | None]:
+        """Solve for the single unspecified parameter and return the full result.
+
+        Whichever of ``power``, ``effect_size``, ``n1``, ``n2``, or ``sig_level``
+        was left as ``None`` is computed (via root-finding for all but ``power``),
+        and the completed set of parameters is returned.
+
+        Returns
+        -------
+        dict[str, float | int | str | None]
+            The resolved parameters (``effect_size``, ``n1``, ``n2``,
+            ``sig_level``, ``power``), along with ``alternative``, ``method``, and
+            ``note`` when a note is present.
+        """
         if self.power is None:
             self.power = self._get_power()
         elif self.effect_size is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,15 +89,19 @@ select = [
     "C4",  # flake8-comprehensions
     "SIM", # flake8-simplify
     "RUF", # Ruff-specific rules
+    "D",   # pydocstyle (numpy-style docstrings)
 ]
 ignore = [
     "E501", # Line too long (handled by formatter)
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "N999"] # Unused imports in __init__.py are OK, module name PyPWR is intentional
 "PyPWR/power_classes.py" = ["N801"] # Class names like pwr_2p intentionally match R's pwr library
-"test/*.py" = ["N801", "N802"] # Test class and method names follow pytest conventions
+"test/**/*.py" = ["N801", "N802", "D"] # Test names follow pytest conventions; docstrings not required on tests
 
 [tool.zuban]
 python_version = "3.13"


### PR DESCRIPTION
## Summary
- Enable ruff's pydocstyle (`D`) rules with `convention = "numpy"` so docstrings are checked for numpy-style structure
- Exempt `test/**/*.py` from docstring rules (and existing naming rules) since pytest tests don't need docstrings
- Add numpy-style docstrings to the two `pwr_test` methods in `PyPWR/power_classes.py` — the only source-level gaps

## Notes
- Source code was already in good shape: only 2 missing docstrings, zero formatting violations
- `ruff check` and `ruff format` both pass clean after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)