### PR TITLE
Derive CI Python test matrix from pyproject.toml classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,45 @@ jobs:
           zuban check PyPWR
         continue-on-error: true
 
+  setup:
+    name: Determine Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ steps.versions.outputs.list }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Derive Python versions from pyproject.toml classifiers
+        id: versions
+        run: |
+          list=$(python - <<'PY'
+          import json, re, tomllib
+          with open("pyproject.toml", "rb") as f:
+              classifiers = tomllib.load(f)["project"]["classifiers"]
+          pat = re.compile(r"Programming Language :: Python :: (\d+\.\d+)$")
+          vs = [m.group(1) for c in classifiers if (m := pat.search(c))]
+          vs.sort(key=lambda v: tuple(map(int, v.split("."))))
+          print(json.dumps(vs))
+          PY
+          )
+          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "Testing against: $list"
+
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.13", "3.14"]
+        python-version: ${{ fromJSON(needs.setup.outputs.python-versions) }}
 
     steps:
       - name: Checkout code
@@ -85,7 +116,7 @@ jobs:
         shell: bash
 
       - name: Upload coverage reports to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == fromJSON(needs.setup.outputs.python-versions)[0]
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml


### PR DESCRIPTION
## Summary

Makes `pyproject.toml` the single source of truth for supported Python versions in CI, so adding a new version is a one-line change.

- New `setup` job parses the `Programming Language :: Python :: 3.x` classifiers and emits a JSON matrix.
- `test` job now `needs: setup` and consumes the matrix via `fromJSON(needs.setup.outputs.python-versions)` instead of the hardcoded `["3.13", "3.14"]`.
- Codecov upload guard keys off the lowest supported version (`fromJSON(...)[0]`) instead of a hardcoded `'3.13'`, so it won't go stale if 3.13 is dropped.

## Why

Previously the version list was duplicated in `ci.yml` and `pyproject.toml` classifiers and had to be kept in sync by hand. Now adding a Python version is a single classifier edit, which also keeps PyPI metadata accurate.

## Notes

`tomllib` is stdlib since 3.11 and the `setup` job pins 3.13, so no extra dependencies are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)