### PR TITLE
Add plot_power: Plotly power-vs-sample-size curves

### DIFF
--- a/PyPWR/__init__.py
+++ b/PyPWR/__init__.py
@@ -12,6 +12,7 @@ from PyPWR.effect_size import (
     es_w1,
     es_w2,
 )
+from PyPWR.plot import plot_power, power_curve
 from PyPWR.pwr_tests import (
     pwr_2p2n_test,
     pwr_2p_test,
@@ -33,6 +34,9 @@ __all__ = [
     "es_h",
     "es_w1",
     "es_w2",
+    # Plotting functions
+    "plot_power",
+    "power_curve",
     "pwr_2p2n_test",
     # Power test functions
     "pwr_2p_test",

--- a/PyPWR/plot.py
+++ b/PyPWR/plot.py
@@ -1,0 +1,357 @@
+"""Power-versus-sample-size plots for :mod:`PyPWR` results.
+
+This module provides a Plotly equivalent of R ``pwr``'s ``plot.power.htest``.
+Given a result dictionary returned by any of the ``pwr_*_test`` functions, it
+sweeps the sample size, recomputes power at each point, and renders an
+interactive power curve with the optimal sample size highlighted.
+
+The heavy lifting (the power computations) is delegated back to the public
+``pwr_*_test`` wrappers, so the curve is always consistent with the value the
+user originally solved for.
+"""
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from PyPWR.pwr_tests import (
+    pwr_2p2n_test,
+    pwr_2p_test,
+    pwr_anova_test,
+    pwr_chisq_test,
+    pwr_norm_test,
+    pwr_p_test,
+    pwr_r_test,
+    pwr_t2n_test,
+    pwr_t_test,
+)
+
+if TYPE_CHECKING:
+    import plotly.graph_objects as go
+
+# Number of intervals along the sample-size axis (matches R's ``breaks``).
+_BREAKS = 20
+
+
+@dataclass
+class PowerCurve:
+    """Data backing a power-versus-sample-size plot.
+
+    Attributes
+    ----------
+    sample_sizes : list[float]
+        Sample sizes swept along the x-axis.
+    powers : list[float]
+        Power at each sample size; ``nan`` where the combination is invalid
+        (e.g. a two-sample split leaving fewer than two observations in a group).
+    optimal_n : int
+        The originally solved sample size, marked with a vertical reference line.
+    step : float
+        Spacing between successive sample sizes.
+    title : str
+        Plot title (the test's ``method`` string).
+    legend_lines : list[str]
+        Parameter summary lines (effect size, alpha, ...).
+    optimal_label : str
+        Annotation text describing the optimal sample size.
+    power_at_optimal : float
+        Power reported by the original result, used for annotation placement.
+    """
+
+    sample_sizes: list[float]
+    powers: list[float]
+    optimal_n: int
+    step: float
+    title: str
+    legend_lines: list[str]
+    optimal_label: str
+    power_at_optimal: float
+
+
+@dataclass(frozen=True)
+class _Spec:
+    """Dispatch configuration for a single plottable test."""
+
+    fn: Callable[..., dict[str, Any]]
+    effect_kwarg: str
+    two_sample: bool
+    uses_alternative: bool
+    effect_label: str
+
+
+# Effect-size label as shown in the R legend, keyed by internal test kind.
+_SPECS: dict[str, _Spec] = {
+    "t": _Spec(pwr_t_test, "d", False, True, "effect size d"),
+    "t2n": _Spec(pwr_t2n_test, "d", True, True, "effect size d"),
+    "2p": _Spec(pwr_2p_test, "h", False, True, "effect size h"),
+    "2p2n": _Spec(pwr_2p2n_test, "h", True, True, "effect size h"),
+    "p": _Spec(pwr_p_test, "h", False, True, "effect size h"),
+    "r": _Spec(pwr_r_test, "r", False, True, "r"),
+    "norm": _Spec(pwr_norm_test, "d", False, True, "effect size d"),
+    "anova": _Spec(pwr_anova_test, "f", False, False, "effect size f"),
+    "chisq": _Spec(pwr_chisq_test, "w", False, False, "effect size w"),
+}
+
+
+def _identify(result: dict[str, Any]) -> str:
+    """Map a result dictionary to an internal test kind.
+
+    Parameters
+    ----------
+    result : dict[str, Any]
+        A dictionary returned by one of the ``pwr_*_test`` functions.
+
+    Returns
+    -------
+    str
+        The internal kind key used to index :data:`_SPECS`.
+
+    Raises
+    ------
+    ValueError
+        If the result is missing a ``method`` field or corresponds to a test
+        that has no single sample-size axis to plot (e.g. ``pwr_f2_test``).
+    """
+    method_raw = result.get("method")
+    if not isinstance(method_raw, str):
+        raise ValueError("result is missing a 'method' field; pass a pwr_*_test result dictionary")
+    method = method_raw.casefold()
+    two_sample = "n1" in result and "n2" in result
+
+    if "multiple regression" in method:
+        raise ValueError(
+            "plot_power does not support pwr_f2_test results: the F2 test has no single "
+            "sample-size axis (it is parameterized by numerator/denominator degrees of freedom)"
+        )
+    if two_sample:
+        return "2p2n" if "proportion" in method else "t2n"
+    if "difference of proportion" in method:
+        return "2p"
+    if "proportion" in method:
+        return "p"
+    if "analysis of variance" in method:
+        return "anova"
+    if "chi squared" in method:
+        return "chisq"
+    if "normal distribution" in method:
+        return "norm"
+    if "correlation" in method:
+        return "r"
+    if "t test" in method:
+        return "t"
+    raise ValueError(f"plot_power does not support results with method {method_raw!r}")
+
+
+def _t_type(method: str) -> str:
+    """Recover the ``test_type`` argument from a t-test ``method`` string."""
+    lowered = method.casefold()
+    if "one sample" in lowered:
+        return "one-sample"
+    if "two sample" in lowered:
+        return "two-sample"
+    return "paired"
+
+
+def _axis(n_total: float) -> tuple[list[float], float]:
+    """Build the sample-size sweep from 10 to ``max(n*1.5, n+30)``."""
+    n_upper = max(n_total * 1.5, n_total + 30)
+    step = (n_upper - 10) / _BREAKS
+    sizes = [10 + i * step for i in range(_BREAKS + 1)]
+    return sizes, step
+
+
+def power_curve(result: dict[str, Any]) -> PowerCurve:
+    """Compute the power-versus-sample-size curve for a test result.
+
+    This is the pure, plotting-library-independent core of :func:`plot_power`.
+    It recomputes power across a range of sample sizes by calling back into the
+    matching ``pwr_*_test`` function, holding the effect size, significance
+    level, and alternative fixed.
+
+    Parameters
+    ----------
+    result : dict[str, Any]
+        A dictionary returned by one of the ``pwr_*_test`` functions.
+
+    Returns
+    -------
+    PowerCurve
+        The swept sample sizes, corresponding powers, and annotation metadata.
+
+    Raises
+    ------
+    ValueError
+        If the result is not a supported, plottable test (see :func:`_identify`).
+    """
+    kind = _identify(result)
+    spec = _SPECS[kind]
+    effect = result["effect_size"]
+    sig_level = result["sig_level"]
+
+    base: dict[str, Any] = {spec.effect_kwarg: effect, "sig_level": sig_level, "print_pretty": False}
+    if spec.uses_alternative:
+        base["alternative"] = result["alternative"]
+    if kind == "anova":
+        base["k"] = result["k"]
+    elif kind == "chisq":
+        base["df"] = result["df"]
+    elif kind == "t":
+        base["test_type"] = _t_type(result["method"])
+
+    legend_lines: list[str] = []
+    if spec.uses_alternative:
+        legend_lines.append(f"tails = {result['alternative']}")
+    if kind == "anova":
+        legend_lines.append(f"groups k = {result['k']}")
+    legend_lines.append(f"{spec.effect_label} = {effect}")
+    if kind == "chisq":
+        legend_lines.append(f"df = {result['df']}")
+
+    powers: list[float] = []
+    if spec.two_sample:
+        n1, n2 = int(result["n1"]), int(result["n2"])
+        total = n1 + n2
+        n_rel = n1 / total
+        sizes, step = _axis(total)
+        for size in sizes:
+            group1 = math.ceil(size * n_rel)
+            group2 = size - group1
+            if group1 < 2 or group2 < 2:
+                powers.append(math.nan)
+                continue
+            powers.append(float(spec.fn(**base, n1=group1, n2=group2)["power"]))
+        optimal_n = total
+        optimal_label = f"optimal sample size<br>n = {n1} + {n2} = {total}"
+        legend_lines.append(f"n1/n2 = {round(n_rel, 2)}")
+    else:
+        n = result["n"]
+        sizes, step = _axis(n)
+        for size in sizes:
+            powers.append(float(spec.fn(**base, n=size)["power"]))
+        optimal_n = math.ceil(n)
+        optimal_label = f"optimal sample size<br>n = {optimal_n}"
+        note = result.get("note")
+        if note:
+            optimal_label += f"<br>{note}"
+
+    legend_lines.append(f"alpha = {sig_level}")
+
+    return PowerCurve(
+        sample_sizes=sizes,
+        powers=powers,
+        optimal_n=optimal_n,
+        step=step,
+        title=str(result["method"]),
+        legend_lines=legend_lines,
+        optimal_label=optimal_label,
+        power_at_optimal=float(result["power"]),
+    )
+
+
+def plot_power(
+    result: dict[str, Any],
+    *,
+    title: str | None = None,
+    xlab: str = "sample size",
+    ylab: str = "test power = 1 - β",
+) -> "go.Figure":  # type: ignore[name-defined]  # plotly ships no type stubs
+    """Plot statistical power as a function of sample size.
+
+    A Plotly equivalent of R ``pwr``'s ``plot.power.htest``. The power curve is
+    drawn as a red line with markers, the originally solved sample size is marked
+    with a dashed vertical line, and the test parameters and optimal sample size
+    are shown as annotations. Hovering a marker reveals the exact sample size and
+    power.
+
+    Parameters
+    ----------
+    result : dict[str, Any]
+        A dictionary returned by one of the ``pwr_*_test`` functions. The
+        ``pwr_f2_test`` result is not supported (it has no sample-size axis).
+    title : str | None, default=None
+        Plot title. Defaults to the test's ``method`` string.
+    xlab : str, default="sample size"
+        Label for the x-axis.
+    ylab : str, default="test power = 1 - β"
+        Label for the y-axis.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        The interactive power-versus-sample-size figure.
+
+    Raises
+    ------
+    ImportError
+        If Plotly is not installed. Install it with ``pip install "pwr-py[plot]"``.
+    ValueError
+        If ``result`` is not a supported, plottable test.
+
+    Examples
+    --------
+    >>> from PyPWR import pwr_t_test, plot_power
+    >>> result = pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample")
+    >>> fig = plot_power(result)  # doctest: +SKIP
+    >>> fig.show()  # doctest: +SKIP
+    """
+    try:
+        import plotly.graph_objects as go
+    except ImportError as exc:  # pragma: no cover - exercised only without plotly
+        raise ImportError('plot_power requires plotly. Install it with: pip install "pwr-py[plot]"') from exc
+
+    curve = power_curve(result)
+
+    valid_powers = [p for p in curve.powers if not math.isnan(p)]
+    min_power = min(valid_powers) if valid_powers else 0.0
+
+    fig = go.Figure()  # type: ignore[attr-defined]  # plotly ships no type stubs
+    fig.add_trace(
+        go.Scatter(  # type: ignore[attr-defined]  # plotly ships no type stubs
+            x=curve.sample_sizes,
+            y=curve.powers,
+            mode="lines+markers",
+            line={"color": "red", "width": 1},
+            marker={"color": "black", "size": 6},
+            connectgaps=False,
+            name="power",
+            hovertemplate="n = %{x:.0f}<br>power = %{y:.1%}<extra></extra>",
+        )
+    )
+    fig.add_vline(x=curve.optimal_n, line={"color": "darkblue", "dash": "dot", "width": 1.5})
+
+    # Legend block: top-left when the curve dips low, bottom-left otherwise, so it
+    # stays clear of the line (mirrors the R placement heuristic).
+    legend_top = min_power < 0.6
+    fig.add_annotation(
+        x=curve.sample_sizes[0],
+        y=1.0 if legend_top else 0.0,
+        xref="x",
+        yref="y",
+        text="<br>".join(curve.legend_lines),
+        showarrow=False,
+        align="left",
+        xanchor="left",
+        yanchor="top" if legend_top else "bottom",
+        font={"size": 12},
+    )
+    # Optimal-n callout: opposite vertical anchor from the legend based on the
+    # solved power, again to avoid overlapping the curve.
+    optimal_top = curve.power_at_optimal < 0.5
+    fig.add_annotation(
+        x=curve.optimal_n + curve.step,
+        y=1.0 if optimal_top else 0.0,
+        xref="x",
+        yref="y",
+        text=curve.optimal_label,
+        showarrow=False,
+        align="left",
+        xanchor="left",
+        yanchor="top" if optimal_top else "bottom",
+        font={"size": 12, "color": "darkblue"},
+    )
+
+    fig.update_xaxes(title_text=xlab)
+    fig.update_yaxes(title_text=ylab, range=[0, 1], tickformat=".0%")
+    fig.update_layout(title=title if title is not None else curve.title, template="plotly_white", showlegend=False)
+    return fig

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Despite the proliferation of A/B testing and experimental design in data science
 - ✅ **Validated Results**: Unit tests ensure compatibility with R's pwr library (differences < 1e-03)
 - 🐍 **Pythonic API**: Clean, modern Python 3.13+ codebase with type hints and comprehensive documentation
 - 🚀 **High Performance**: Leverages NumPy and SciPy for efficient numerical computations
+- 📈 **Interactive Plots**: Optional Plotly power-versus-sample-size curves (a port of R pwr's `plot.power.htest`)
 
 ## Table of Contents
 
@@ -50,11 +51,20 @@ cd pyPWR
 pip install -e .
 ```
 
+### Optional: plotting support
+
+Power-curve plotting requires Plotly, which is an optional extra:
+
+```bash
+pip install "pwr-py[plot]"
+```
+
 ### Requirements
 
 - Python 3.13 or higher
 - NumPy >= 2.2.4
 - SciPy >= 1.15.2
+- Plotly >= 5.0.0 (optional, for `plot_power`)
 
 ## Quick Start
 
@@ -187,6 +197,22 @@ result = pwr_t_test(d=effect["effect_size"], n=30, sig_level=0.05, type="paired"
 
 print(f"Power with n=30 and d=0.5: {result['power']:.2%}")
 ```
+
+### Example 6: Plotting Power vs. Sample Size
+
+Requires the `plot` extra (`pip install "pwr-py[plot]"`). Pass any `pwr_*_test`
+result to `plot_power` to get an interactive Plotly figure of power as a
+function of sample size, with the solved sample size marked:
+
+```python
+from PyPWR import pwr_t_test, plot_power
+
+result = pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample")
+fig = plot_power(result)
+fig.show()  # opens an interactive figure; also fig.write_html("power.html")
+```
+
+The `pwr_f2_test` result is not plottable (it has no single sample-size axis).
 
 ## Effect Size Calculations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ dependencies = [
     "scipy>=1.15.2,<2.0.0"
 ]
 
+[project.optional-dependencies]
+plot = [
+    "plotly>=5.0.0"
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.3.5",
@@ -45,7 +50,8 @@ dev = [
     "ruff>=0.8.0",
     "zuban>=0.1.0",
     "autopep8>=2.3.0",
-    "pydocstringformatter>=0.7.3"
+    "pydocstringformatter>=0.7.3",
+    "plotly>=5.0.0"
 ]
 
 [project.urls]

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -1,0 +1,115 @@
+"""Tests for the power-versus-sample-size plotting module."""
+
+import math
+from itertools import pairwise
+
+import pytest
+
+from PyPWR import (
+    plot_power,
+    power_curve,
+    pwr_2p2n_test,
+    pwr_2p_test,
+    pwr_anova_test,
+    pwr_chisq_test,
+    pwr_f2_test,
+    pwr_norm_test,
+    pwr_p_test,
+    pwr_r_test,
+    pwr_t2n_test,
+    pwr_t_test,
+)
+
+# One representative result per plottable test kind, each solved for sample size.
+_SINGLE_N_RESULTS = [
+    pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample", print_pretty=False),
+    pwr_t_test(n=34, d=0.5, sig_level=0.05, test_type="one-sample", print_pretty=False),
+    pwr_2p_test(h=0.3, power=0.8, sig_level=0.05, print_pretty=False),
+    pwr_p_test(h=0.3, power=0.8, sig_level=0.05, print_pretty=False),
+    pwr_r_test(r=0.3, power=0.8, sig_level=0.05, print_pretty=False),
+    pwr_norm_test(d=0.3, power=0.8, sig_level=0.05, print_pretty=False),
+    pwr_anova_test(k=4, f=0.25, power=0.8, sig_level=0.05, print_pretty=False),
+    pwr_chisq_test(w=0.3, df=4, power=0.8, sig_level=0.05, print_pretty=False),
+]
+
+_TWO_SAMPLE_RESULTS = [
+    pwr_t2n_test(n1=40, n2=60, d=0.5, sig_level=0.05, print_pretty=False),
+    pwr_2p2n_test(h=0.3, n1=80, n2=120, sig_level=0.05, print_pretty=False),
+]
+
+
+class TestPowerCurve:
+    """Tests for the pure ``power_curve`` data generator."""
+
+    @pytest.mark.parametrize("result", _SINGLE_N_RESULTS + _TWO_SAMPLE_RESULTS)
+    def test_curve_shape(self, result):
+        curve = power_curve(result)
+        # 20 breaks -> 21 points.
+        assert len(curve.sample_sizes) == 21
+        assert len(curve.powers) == 21
+        # Every non-nan power is a valid probability.
+        for p in curve.powers:
+            assert math.isnan(p) or 0.0 <= p <= 1.0
+        # Sample sizes are strictly increasing starting at 10.
+        assert curve.sample_sizes[0] == 10
+        assert all(b > a for a, b in pairwise(curve.sample_sizes))
+
+    @pytest.mark.parametrize("result", _SINGLE_N_RESULTS)
+    def test_optimal_n_matches_single(self, result):
+        curve = power_curve(result)
+        assert curve.optimal_n == math.ceil(result["n"])
+
+    @pytest.mark.parametrize("result", _TWO_SAMPLE_RESULTS)
+    def test_optimal_n_matches_two_sample(self, result):
+        curve = power_curve(result)
+        assert curve.optimal_n == result["n1"] + result["n2"]
+
+    def test_power_increases_with_sample_size(self):
+        # Power is monotonically non-decreasing in n for a fixed effect/alpha.
+        curve = power_curve(pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample", print_pretty=False))
+        powers = [p for p in curve.powers if not math.isnan(p)]
+        assert all(b >= a - 1e-9 for a, b in pairwise(powers))
+
+    def test_legend_contains_effect_and_alpha(self):
+        curve = power_curve(pwr_anova_test(k=4, f=0.25, power=0.8, sig_level=0.05, print_pretty=False))
+        joined = "\n".join(curve.legend_lines)
+        assert "groups k = 4" in joined
+        assert "effect size f = 0.25" in joined
+        assert "alpha = 0.05" in joined
+
+    def test_f2_result_is_rejected(self):
+        result = pwr_f2_test(u=5, v=89, f2=0.1, sig_level=0.05, print_pretty=False)
+        with pytest.raises(ValueError, match="pwr_f2_test"):
+            power_curve(result)
+
+    def test_missing_method_is_rejected(self):
+        with pytest.raises(ValueError, match="method"):
+            power_curve({"effect_size": 0.5, "n": 30, "sig_level": 0.05, "power": 0.8})
+
+
+class TestPlotPower:
+    """Tests for the Plotly rendering wrapper."""
+
+    def test_returns_figure(self):
+        go = pytest.importorskip("plotly.graph_objects")
+        result = pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample", print_pretty=False)
+        fig = plot_power(result)
+        assert isinstance(fig, go.Figure)
+
+    def test_figure_has_curve_and_optimal_line(self):
+        pytest.importorskip("plotly")
+        result = pwr_2p2n_test(h=0.3, n1=80, n2=120, sig_level=0.05, print_pretty=False)
+        fig = plot_power(result)
+        # One scatter trace for the power curve.
+        assert len(fig.data) == 1
+        assert fig.data[0].mode == "lines+markers"
+        # A dashed vertical line (a shape) marks the optimal sample size.
+        assert any(shape.type == "line" for shape in fig.layout.shapes)
+        # Two annotations: parameter legend and optimal-n callout.
+        assert len(fig.layout.annotations) == 2
+
+    def test_title_override(self):
+        pytest.importorskip("plotly")
+        result = pwr_r_test(r=0.3, power=0.8, sig_level=0.05, print_pretty=False)
+        fig = plot_power(result, title="Custom Title")
+        assert fig.layout.title.text == "Custom Title"

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -136,6 +145,19 @@ wheels = [
 ]
 
 [[package]]
+name = "plotly"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/18/d8544811ab076f876c4892b3714f5b0dad335e1dc33aef826df431b8325d/plotly-6.9.0-py3-none-any.whl", hash = "sha256:36bebe2f1bb13884774fe61689c329071446f6ce4a8927fb1f0d6fb24f581236", size = 9909646, upload-time = "2026-07-09T14:55:55.421Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -153,9 +175,15 @@ dependencies = [
     { name = "scipy" },
 ]
 
+[package.optional-dependencies]
+plot = [
+    { name = "plotly" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "autopep8" },
+    { name = "plotly" },
     { name = "pydocstringformatter" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -166,12 +194,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=2.2.4,<3.0.0" },
+    { name = "plotly", marker = "extra == 'plot'", specifier = ">=5.0.0" },
     { name = "scipy", specifier = ">=1.15.2,<2.0.0" },
 ]
+provides-extras = ["plot"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "autopep8", specifier = ">=2.3.0" },
+    { name = "plotly", specifier = ">=5.0.0" },
     { name = "pydocstringformatter", specifier = ">=0.7.3" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },


### PR DESCRIPTION
## What

A Plotly port of R pwr's [`plot.power.htest`](https://github.com/heliosdrm/pwr/blob/master/R/plot.power.htest.R). Pass any `pwr_*_test` result dict to `plot_power()` to get an interactive power-versus-sample-size curve with the solved sample size marked.

```python
from PyPWR import pwr_t_test, plot_power

result = pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample")
plot_power(result).show()
```

## How

- **`power_curve(result)`** — pure, plotting-library-free core: sweeps sample size `10 -> max(n*1.5, n+30)` in 20 steps and recomputes power by calling back into the existing `pwr_*_test` wrappers (so the curve always matches what the user solved for). Returns a typed `PowerCurve`. Fully unit-testable.
- **`plot_power(result, *, title, xlab, ylab)`** — renders the figure: red line+markers, dashed vertical line at optimal `n`, percentage y-axis, and parameter/optimal-`n` annotations using R's position-flipping heuristic. Adds **hover tooltips** the static ggplot original can't.
- Dispatch resolves the two method-string collisions (`2p`/`2p2n`, `t`/`t2n`) via dict shape (`n1`/`n2` presence); `pwr_f2_test` is rejected with a clear error (no single sample-size axis — parity with R).
- `plotly` is an optional **`[plot]`** extra, lazily imported with a friendly install error; also added to the `dev` group so CI runs the tests.

## Verification

- **95 tests pass** (27 new), coverage **90%**
- `plot.py` is zuban-clean; ruff format + lint green
- End-to-end render confirmed (1 curve trace, 1 optimal-`n` line, 2 annotations, valid HTML)

## Note (out of scope)

Found a **pre-existing** bug: `pwr_t_test(d=.., power=..)` (solving for `n`) crashes in the brentq solver with a NaN function value, for one- and two-sample types. Unrelated to plotting (the sweep solves for power); worked around in tests/docs by supplying `n`. Worth a separate issue/fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)