### PR TITLE
Fix NaN crash when solving pwr_t_test / pwr_t2n_test for n

### DIFF
--- a/PyPWR/power_classes.py
+++ b/PyPWR/power_classes.py
@@ -1072,89 +1072,42 @@ class pwr_t:
             self.note = "n is the number in each group"
             self.t_sample = 2
 
+    def _power(self, n: float, d: float, sig_level: float) -> float:
+        """Return t-test power for the given n, effect size, and significance level."""
+        nu = (n - 1) * self.t_sample
+        ncp = sqrt(n / self.t_sample) * d
+        if self.alternative == "two-sided":
+            qu = t_dist.isf(sig_level / 2, nu)
+            # Probability of rejecting in the wrong tail. For a large effect size
+            # or large df this underflows to ~0, but scipy's noncentral-t can
+            # return NaN here instead of 0, which would break the root-finders in
+            # pwr_test (e.g. solving for n over the wide [2, 1e9] bracket). Treat a
+            # NaN as the 0 it is converging to.
+            wrong_tail = nct.cdf(-qu, nu, ncp)
+            if np.isnan(wrong_tail):
+                wrong_tail = 0.0
+            power = nct.sf(qu, nu, ncp) + wrong_tail
+        elif self.alternative == "greater":
+            power = nct.sf(t_dist.isf(sig_level, nu), nu, ncp)
+        else:
+            power = nct.cdf(t_dist.ppf(sig_level, nu), nu, ncp)
+        return float(power)
+
     def _get_power(self) -> float:
         assert self.n is not None and self.sig_level is not None and self.d is not None
-        nu = (self.n - 1) * self.t_sample
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(self.sig_level / 2, nu)
-            power = nct.sf(qu, nu, sqrt(self.n / self.t_sample) * self.d) + nct.cdf(
-                -qu, nu, sqrt(self.n / self.t_sample) * self.d
-            )
-        elif self.alternative == "greater":
-            power = nct.sf(
-                t_dist.isf(self.sig_level, nu),
-                nu,
-                sqrt(self.n / self.t_sample) * self.d,
-            )
-        else:
-            power = nct.cdf(
-                t_dist.ppf(self.sig_level, nu),
-                nu,
-                sqrt(self.n / self.t_sample) * self.d,
-            )
-        return float(power)
+        return self._power(self.n, self.d, self.sig_level)
 
     def _get_effect_size(self, effect_size: float) -> float:
         assert self.n is not None and self.sig_level is not None and self.power is not None
-        nu = (self.n - 1) * self.t_sample
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(self.sig_level / 2, nu)
-            effect_size = (
-                nct.sf(qu, nu, sqrt(self.n / self.t_sample) * effect_size)
-                + nct.cdf(-qu, nu, sqrt(self.n / self.t_sample) * effect_size)
-                - self.power
-            )
-        elif self.alternative == "greater":
-            effect_size = (
-                nct.sf(
-                    t_dist.isf(self.sig_level, nu),
-                    nu,
-                    sqrt(self.n / self.t_sample) * effect_size,
-                )
-                - self.power
-            )
-        else:
-            effect_size = (
-                nct.cdf(
-                    t_dist.ppf(self.sig_level, nu),
-                    nu,
-                    sqrt(self.n / self.t_sample) * effect_size,
-                )
-                - self.power
-            )
-        return effect_size
+        return self._power(self.n, effect_size, self.sig_level) - self.power
 
     def _get_n(self, n: int) -> float:
         assert self.sig_level is not None and self.d is not None and self.power is not None
-        nu = (n - 1) * self.t_sample
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(self.sig_level / 2, nu)
-            n = (
-                nct.sf(qu, nu, sqrt(n / self.t_sample) * self.d)
-                + nct.cdf(-qu, nu, sqrt(n / self.t_sample) * self.d)
-                - self.power
-            )
-        elif self.alternative == "greater":
-            n = nct.sf(t_dist.isf(self.sig_level, nu), nu, sqrt(n / self.t_sample) * self.d) - self.power
-        else:
-            n = nct.cdf(t_dist.ppf(self.sig_level, nu), nu, sqrt(n / self.t_sample) * self.d) - self.power
-        return n
+        return self._power(n, self.d, self.sig_level) - self.power
 
     def _get_sig_level(self, sig_level: float) -> float:
         assert self.n is not None and self.d is not None and self.power is not None
-        nu = (self.n - 1) * self.t_sample
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(sig_level / 2, nu)
-            sig_level = (
-                nct.sf(qu, nu, sqrt(self.n / self.t_sample) * self.d)
-                + nct.cdf(-qu, nu, sqrt(self.n / self.t_sample) * self.d)
-                - self.power
-            )
-        elif self.alternative == "greater":
-            sig_level = nct.sf(t_dist.isf(sig_level, nu), nu, sqrt(self.n / self.t_sample) * self.d) - self.power
-        else:
-            sig_level = nct.cdf(t_dist.ppf(sig_level, nu), nu, sqrt(self.n / self.t_sample) * self.d) - self.power
-        return sig_level
+        return self._power(self.n, self.d, sig_level) - self.power
 
     def pwr_test(self) -> dict[str, int | float | str | None]:
         """Perform power calculation for t-test."""
@@ -1228,59 +1181,33 @@ class pwr_t2n(pwr_2n):
         super().__init__(d, n1, n2, sig_level, power, alternative)
         self.method = "T test power calculation"
 
+    def _power(self, n1: float, n2: float, effect_size: float, sig_level: float) -> float:
+        """Return two-sample t-test power for the given sizes, effect size, and significance level."""
+        nu = n1 + n2 - 2
+        ncp = effect_size * (1 / sqrt(1 / n1 + 1 / n2))
+        if self.alternative == "two-sided":
+            qu = t_dist.isf(sig_level / 2, nu)
+            # As in pwr_t._power, guard the wrong-tail term: scipy's noncentral-t
+            # can return NaN where this probability underflows to ~0.
+            wrong_tail = nct.cdf(-qu, nu, ncp)
+            if np.isnan(wrong_tail):
+                wrong_tail = 0.0
+            power = nct.sf(qu, nu, ncp) + wrong_tail
+        elif self.alternative == "greater":
+            power = nct.sf(t_dist.isf(sig_level, nu), nu, ncp)
+        else:
+            power = nct.cdf(t_dist.ppf(sig_level, nu), nu, ncp)
+        return float(power)
+
     def _get_power(self) -> float:
         assert (
             self.sig_level is not None and self.n1 is not None and self.n2 is not None and self.effect_size is not None
         )
-        nu = self.n1 + self.n2 - 2
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(self.sig_level / 2, nu)
-            power = nct.sf(qu, nu, self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2))) + nct.cdf(
-                -qu, nu, self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2))
-            )
-        elif self.alternative == "greater":
-            power = nct.sf(
-                t_dist.isf(self.sig_level, nu),
-                nu,
-                self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)),
-            )
-        else:
-            power = nct.cdf(
-                t_dist.ppf(self.sig_level, nu),
-                nu,
-                self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)),
-            )
-        return float(power)
+        return self._power(self.n1, self.n2, self.effect_size, self.sig_level)
 
     def _get_effect_size(self, effect_size: float) -> float:
         assert self.sig_level is not None and self.n1 is not None and self.n2 is not None and self.power is not None
-        nu = self.n1 + self.n2 - 2
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(self.sig_level / 2, nu)
-            effect_size = (
-                nct.sf(qu, nu, effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)))
-                + nct.cdf(-qu, nu, effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)))
-                - self.power
-            )
-        elif self.alternative == "greater":
-            effect_size = (
-                nct.sf(
-                    t_dist.isf(self.sig_level, nu),
-                    nu,
-                    effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)),
-                )
-                - self.power
-            )
-        else:
-            effect_size = (
-                nct.cdf(
-                    t_dist.ppf(self.sig_level, nu),
-                    nu,
-                    effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)),
-                )
-                - self.power
-            )
-        return effect_size
+        return self._power(self.n1, self.n2, effect_size, self.sig_level) - self.power
 
     def _get_n1(self, n1: int) -> float:
         assert (
@@ -1289,33 +1216,7 @@ class pwr_t2n(pwr_2n):
             and self.effect_size is not None
             and self.power is not None
         )
-        nu = n1 + self.n2 - 2
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(self.sig_level / 2, nu)
-            n1 = (
-                nct.sf(qu, nu, self.effect_size * (1 / sqrt(1 / n1 + 1 / self.n2)))
-                + nct.cdf(-qu, nu, self.effect_size * (1 / sqrt(1 / n1 + 1 / self.n2)))
-                - self.power
-            )
-        elif self.alternative == "greater":
-            n1 = (
-                nct.sf(
-                    t_dist.isf(self.sig_level, nu),
-                    nu,
-                    self.effect_size * (1 / sqrt(1 / n1 + 1 / self.n2)),
-                )
-                - self.power
-            )
-        else:
-            n1 = (
-                nct.cdf(
-                    t_dist.ppf(self.sig_level, nu),
-                    nu,
-                    self.effect_size * (1 / sqrt(1 / n1 + 1 / self.n2)),
-                )
-                - self.power
-            )
-        return n1
+        return self._power(n1, self.n2, self.effect_size, self.sig_level) - self.power
 
     def _get_n2(self, n2: int) -> float:
         assert (
@@ -1324,63 +1225,11 @@ class pwr_t2n(pwr_2n):
             and self.effect_size is not None
             and self.power is not None
         )
-        nu = self.n1 + n2 - 2
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(self.sig_level / 2, nu)
-            n2 = (
-                nct.sf(qu, nu, self.effect_size * (1 / sqrt(1 / self.n1 + 1 / n2)))
-                + nct.cdf(-qu, nu, self.effect_size * (1 / sqrt(1 / self.n1 + 1 / n2)))
-                - self.power
-            )
-        elif self.alternative == "greater":
-            n2 = (
-                nct.sf(
-                    t_dist.isf(self.sig_level, nu),
-                    nu,
-                    self.effect_size * (1 / sqrt(1 / self.n1 + 1 / n2)),
-                )
-                - self.power
-            )
-        else:
-            n2 = (
-                nct.cdf(
-                    t_dist.ppf(self.sig_level, nu),
-                    nu,
-                    self.effect_size * (1 / sqrt(1 / self.n1 + 1 / n2)),
-                )
-                - self.power
-            )
-        return n2
+        return self._power(self.n1, n2, self.effect_size, self.sig_level) - self.power
 
     def _get_sig_level(self, sig_level: float) -> float:
         assert self.n1 is not None and self.n2 is not None and self.effect_size is not None and self.power is not None
-        nu = self.n1 + self.n2 - 2
-        if self.alternative == "two-sided":
-            qu = t_dist.isf(sig_level / 2, nu)
-            sig_level = (
-                nct.sf(qu, nu, self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)))
-                + nct.cdf(-qu, nu, self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)))
-                - self.power
-            )
-        elif self.alternative == "greater":
-            sig_level = (
-                nct.sf(
-                    t_dist.isf(sig_level, nu),
-                    nu,
-                    self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)),
-                )
-                - self.power
-            )
-        else:
-            sig_level = (
-                nct.cdf(
-                    t_dist.ppf(sig_level, nu),
-                    nu,
-                    self.effect_size * (1 / sqrt(1 / self.n1 + 1 / self.n2)),
-                )
-                - self.power
-            )
-        return sig_level
+        return self._power(self.n1, self.n2, self.effect_size, sig_level) - self.power
 
     def pwr_test(self) -> dict[str, int | float | str | None]:
         """Perform power calculation for two-sample t-test with unequal sizes."""

--- a/test/test_pwr.py
+++ b/test/test_pwr.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 from PyPWR import pwr_tests
@@ -874,6 +876,26 @@ class Test_T:
         expected = 0.3725015
         assert s_results["sig_level"] == pytest.approx(expected, 0.001)
 
+    @staticmethod
+    def test_t_solve_n_two_sided() -> None:
+        # Regression: solving for n with a two-sided alternative used to crash
+        # because scipy's noncentral-t returns NaN for the (negligible) wrong-tail
+        # term at large n, which the brentq [2, 1e9] bracket walks into.
+        # pwr.t.test(d=0.5, power=0.8, sig.level=0.05, type="two.sample") -> n = 63.76561
+        two_sample = pwr_tests.pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="two-sample", print_pretty=False)
+        assert two_sample["n"] == 64
+        # pwr.t.test(d=0.5, power=0.8, sig.level=0.05, type="one.sample") -> n = 33.36713
+        one_sample = pwr_tests.pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="one-sample", print_pretty=False)
+        assert one_sample["n"] == 34
+
+    @staticmethod
+    def test_t_power_large_n_is_finite() -> None:
+        # Regression: forward power at large n must not return NaN (the wrong-tail
+        # guard). At n=5000, d=0.5 the test is essentially certain to reject.
+        result = pwr_tests.pwr_t_test(n=5000, d=0.5, sig_level=0.05, test_type="two-sample", print_pretty=False)
+        assert math.isfinite(result["power"])
+        assert result["power"] == pytest.approx(1.0, abs=1e-9)
+
 
 class Test_T2N:
     @staticmethod
@@ -987,6 +1009,14 @@ class Test_T2N:
         #     alternative = greater
         expected = 0.2146133
         assert s_results["sig_level"] == pytest.approx(expected, 0.0001)
+
+    @staticmethod
+    def test_t2n_power_large_n_is_finite() -> None:
+        # Regression: same wrong-tail NaN guard as pwr_t, exercised via large
+        # group sizes (pwr_t2n takes n1/n2 directly rather than solving for them).
+        result = pwr_tests.pwr_t2n_test(n1=5000, n2=5000, d=0.5, sig_level=0.05, print_pretty=False)
+        assert math.isfinite(result["power"])
+        assert result["power"] == pytest.approx(1.0, abs=1e-9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

`pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="two-sample")` — solving for **n** with a **two-sided** alternative — crashes with `The function value at x=... is NaN; solver cannot continue`. Same latent issue affects `pwr_t2n_test` forward power at large group sizes.

## Root cause

Two things combine:

1. **scipy's noncentral-t returns `NaN`, not 0**, for the *wrong-tail* rejection probability `nct.cdf(-qu, nu, ncp)` at large df + noncentrality (e.g. `nct.cdf(-1.96, 5998, 19.36)` → `NaN`, yet fine at ncp=15 and ncp=25 — the failures are patchy). This term is the probability of rejecting in the direction *opposite* a real effect: mathematically ~1e-106, i.e. negligibly 0.
2. **The solver bracket is `[2, 1e9]`.** With the root at n≈64 but the bracket 15-million-fold wider, `brentq` probes deep into the NaN-prone region (it crashed at n≈6005) before converging.

R doesn't hit this because its `pt(ncp=)` returns the tiny value instead of `NaN`, so `uniroot` over the *same* bracket survives. It went unnoticed because the only existing solve-for-n test used `alternative="greater"`, a different (single-tail, robust) code path.

## The fix

Guard the wrong-tail term (`NaN -> 0.0`, the value it underflows to) inside a shared `_power` helper, applied to both `pwr_t` and `pwr_t2n` (the two `nct`-based classes; the others use the robust normal approximation). This also collapses the 4x/5x duplicated `_get_*` branch blocks in each class into one helper — **net -121 lines**.

## Verification

- All 9 combos (3 types x 3 alternatives) now solve for n; two-sided matches R exactly: two-sample n=64 (R 63.77), one-sample/paired n=34 (R 33.37).
- Forward power **unchanged**: n=64, d=0.5 -> 0.801460 (R 0.8014596).
- **98 tests pass** (+3 regression: two-sided solve-for-n, plus large-n finiteness for `pwr_t`/`pwr_t2n`); coverage 92.5%; ruff format + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)