### PR TITLE
Simplify t-test plotting fixtures now that solve-for-n works

### DIFF
--- a/PyPWR/plot.py
+++ b/PyPWR/plot.py
@@ -291,7 +291,7 @@ def plot_power(
     Examples
     --------
     >>> from PyPWR import pwr_t_test, plot_power
-    >>> result = pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample")
+    >>> result = pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="two-sample")
     >>> fig = plot_power(result)  # doctest: +SKIP
     >>> fig.show()  # doctest: +SKIP
     """

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -22,8 +22,8 @@ from PyPWR import (
 
 # One representative result per plottable test kind, each solved for sample size.
 _SINGLE_N_RESULTS = [
-    pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample", print_pretty=False),
-    pwr_t_test(n=34, d=0.5, sig_level=0.05, test_type="one-sample", print_pretty=False),
+    pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="two-sample", print_pretty=False),
+    pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="one-sample", print_pretty=False),
     pwr_2p_test(h=0.3, power=0.8, sig_level=0.05, print_pretty=False),
     pwr_p_test(h=0.3, power=0.8, sig_level=0.05, print_pretty=False),
     pwr_r_test(r=0.3, power=0.8, sig_level=0.05, print_pretty=False),
@@ -66,7 +66,7 @@ class TestPowerCurve:
 
     def test_power_increases_with_sample_size(self):
         # Power is monotonically non-decreasing in n for a fixed effect/alpha.
-        curve = power_curve(pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample", print_pretty=False))
+        curve = power_curve(pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="two-sample", print_pretty=False))
         powers = [p for p in curve.powers if not math.isnan(p)]
         assert all(b >= a - 1e-9 for a, b in pairwise(powers))
 
@@ -92,7 +92,7 @@ class TestPlotPower:
 
     def test_returns_figure(self):
         go = pytest.importorskip("plotly.graph_objects")
-        result = pwr_t_test(n=64, d=0.5, sig_level=0.05, test_type="two-sample", print_pretty=False)
+        result = pwr_t_test(d=0.5, power=0.8, sig_level=0.05, test_type="two-sample", print_pretty=False)
         fig = plot_power(result)
         assert isinstance(fig, go.Figure)
 


### PR DESCRIPTION
Follow-up cleanup to #25 and #26.

The plotting tests and the `plot_power` docstring example (added in #25) passed an explicit `n` to `pwr_t_test` to dodge the solve-for-n NaN crash. That crash was fixed in #26, so this reverts them to the natural `d`/`power` form — matching the other plotting fixtures (2p, anova, chisq, …) which already solve for `n`.

- `test/test_plot.py`: `pwr_t_test(n=64, …)` / `pwr_t_test(n=34, …)` → `pwr_t_test(d=0.5, power=0.8, …)`
- `PyPWR/plot.py`: same in the docstring example

No behavior change: `power_curve`'s `optimal_n` still equals `ceil(result["n"])`, which is 64/34 for these inputs.

## Verification

- **98 tests pass**; ruff format + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)