### PR TITLE
Fix stale install commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Despite the proliferation of A/B testing and experimental design in data science
 ### From PyPI (when available)
 
 ```bash
-pip install pypwr
+pip install pwr-py
 ```
 
 ### From Source
@@ -328,7 +328,7 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 ```bash
 git clone https://github.com/ConorMcNamara/pyPWR.git
 cd pyPWR
-pip install -e ".[dev]"  # Install with development dependencies
+uv sync  # Install with development dependencies
 ```
 
 ### Running Tests


### PR DESCRIPTION
Cleans up two post-migration leftovers in the README install docs:

- **`pip install pypwr` → `pip install pwr-py`** — the distribution was renamed in #24 (the old `pypwr` name is taken on PyPI by an unrelated package).
- **`pip install -e ".[dev]"` → `uv sync`** — the `dev` extra became a `[dependency-groups]` group in #24, so `.[dev]` no longer resolves. This matches the uv workflow already documented in CONTRIBUTING.md.

The `pip install -e .` source-install line is left as-is (still valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)