### PR TITLE
Bump pytest to >=9.0.3 for security fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ plot = [
 
 [dependency-groups]
 dev = [
-    "pytest>=8.3.5",
+    "pytest>=9.0.3",
     "pytest-cov>=6.0.0",
     "ruff>=0.8.0",
     "zuban>=0.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ dev = [
     { name = "autopep8", specifier = ">=2.3.0" },
     { name = "plotly", specifier = ">=5.0.0" },
     { name = "pydocstringformatter", specifier = ">=0.7.3" },
-    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "zuban", specifier = ">=0.1.0" },


### PR DESCRIPTION
## Summary
- Bump the `pytest` dev dependency from `>=8.3.5` to `>=9.0.3` to address a security vulnerability
- Re-locked (`uv lock`) and synced; resolves to pytest 9.1.1

## Test plan
- `uv run pytest` — all 98 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)